### PR TITLE
🐛 Resolve #16 by adding defined check for EnumConverter 

### DIFF
--- a/VCF.Core/Registry/CommandRegistry.cs
+++ b/VCF.Core/Registry/CommandRegistry.cs
@@ -164,13 +164,25 @@ public static class CommandRegistry
 					return CommandResult.InternalError;
 				}
 			}
+			// Default Converter
 			else
 			{
-				// default convertet
-				var builtinConverter = TypeDescriptor.GetConverter(param.ParameterType);
+				var defaultConverter = TypeDescriptor.GetConverter(param.ParameterType);
 				try
 				{
-					commandArgs[i + 1] = builtinConverter.ConvertFromInvariantString(arg);
+					var val = defaultConverter.ConvertFromInvariantString(arg);
+
+					// ensure enums are valid for #16
+					if (defaultConverter is EnumConverter)
+					{
+						if (!Enum.IsDefined(param.ParameterType, val))
+						{
+							ctx.Reply($"<color=red>[error]</color> Invalid value {val} for {param.ParameterType.Name}");
+							return CommandResult.UsageError;
+						}
+					}
+					
+					commandArgs[i + 1] = val;
 				}
 				catch (Exception e)
 				{

--- a/VCF.Tests/ParsingTests.cs
+++ b/VCF.Tests/ParsingTests.cs
@@ -78,6 +78,14 @@ public class ParsingTests
 		Assert.That(CommandRegistry.Handle(AnyCtx, ".horse color Brown"), Is.EqualTo(CommandResult.Success));
 		Assert.That(CommandRegistry.Handle(AnyCtx, ".horse color Purple"), Is.EqualTo(CommandResult.UsageError));
 	}
+	
+	[Test]
+	public void CanCallWithEnumValues()
+	{
+		Assert.That(CommandRegistry.Handle(AnyCtx, ".horse color 1"), Is.EqualTo(CommandResult.Success));
+		Assert.That(CommandRegistry.Handle(AnyCtx, ".horse color 2"), Is.EqualTo(CommandResult.Success));
+		Assert.That(CommandRegistry.Handle(AnyCtx, ".horse color 4"), Is.EqualTo(CommandResult.UsageError));
+	}
 
 	[Test]
 	public void CommandsCanBeSubstrings()


### PR DESCRIPTION
This is intended to resolve decaprime/CommunityCommands#12 indirectly and prevent this class of error downstream.