### PR TITLE
resolve issue occuring when scanned assembly contains an interface

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,5 +3,6 @@
   <packageSources>
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
     <add key="Samboy Feed" value="https://nuget.samboy.dev/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/VCF.Core/Registry/CommandRegistry.cs
+++ b/VCF.Core/Registry/CommandRegistry.cs
@@ -276,8 +276,8 @@ public static class CommandRegistry
 		}
 	}
 
-	internal static bool IsGenericConverterContext(Type rootType) => rootType.BaseType.Name == typeof(CommandArgumentConverter<>).Name;
-	internal static bool IsSpecificConverterContext(Type rootType) => rootType.BaseType.Name == typeof(CommandArgumentConverter<,>).Name;
+	internal static bool IsGenericConverterContext(Type rootType) => rootType?.BaseType?.Name == typeof(CommandArgumentConverter<>).Name;
+	internal static bool IsSpecificConverterContext(Type rootType) => rootType?.BaseType?.Name == typeof(CommandArgumentConverter<,>).Name;
 
 	public static void RegisterConverter(Type converter)
 	{

--- a/VCF.Tests/AssertReplyContext.cs
+++ b/VCF.Tests/AssertReplyContext.cs
@@ -25,21 +25,23 @@ public class AssertReplyContext : ICommandContext
 
 	public void AssertReply(string expected)
 	{
-		Assert.That(RepliedTextTrimmed(), Is.EqualTo(expected));
+		Assert.That(RepliedTextLfAndTrimmed(), Is.EqualTo(expected));
 	}
 	public void AssertReplyContains(string expected)
 	{
-		var repliedText = RepliedTextTrimmed();
+		var repliedText = RepliedTextLfAndTrimmed();
 		Assert.That(repliedText.Contains(expected), Is.True, $"Expected {expected} to be contained in replied: {repliedText}");
 	}
 
 	public void AssertInternalError()
 	{
-		Assert.That(RepliedTextTrimmed(), Is.EqualTo("[vcf] An internal error has occurred."));
+		Assert.That(RepliedTextLfAndTrimmed(), Is.EqualTo("[vcf] An internal error has occurred."));
 	}
 
-	private string RepliedTextTrimmed()
+	private string RepliedTextLfAndTrimmed()
 	{
-		return _sb.ToString().TrimEnd(Environment.NewLine.ToCharArray());
+		return _sb.ToString()
+			.Replace("\r\n", "\n") // LF instead of CRLF for line endings
+			.TrimEnd(Environment.NewLine.ToCharArray());
 	}
 }

--- a/VCF.Tests/AssertReplyContext.cs
+++ b/VCF.Tests/AssertReplyContext.cs
@@ -25,16 +25,21 @@ public class AssertReplyContext : ICommandContext
 
 	public void AssertReply(string expected)
 	{
-		Assert.That(_sb.ToString().TrimEnd(Environment.NewLine.ToCharArray()), Is.EqualTo(expected));
+		Assert.That(RepliedTextTrimmed(), Is.EqualTo(expected));
 	}
 	public void AssertReplyContains(string expected)
 	{
-		var repliedText = _sb.ToString().TrimEnd(Environment.NewLine.ToCharArray());
+		var repliedText = RepliedTextTrimmed();
 		Assert.That(repliedText.Contains(expected), Is.True, $"Expected {expected} to be contained in replied: {repliedText}");
 	}
 
 	public void AssertInternalError()
 	{
-		Assert.That(_sb.ToString().TrimEnd(Environment.NewLine.ToCharArray()), Is.EqualTo("[vcf] An internal error has occurred."));
+		Assert.That(RepliedTextTrimmed(), Is.EqualTo("[vcf] An internal error has occurred."));
+	}
+
+	private string RepliedTextTrimmed()
+	{
+		return _sb.ToString().TrimEnd(Environment.NewLine.ToCharArray());
 	}
 }

--- a/VCF.Tests/InitializationTests.cs
+++ b/VCF.Tests/InitializationTests.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using FakeItEasy;
+using NUnit.Framework;
+using VampireCommandFramework;
+
+namespace VCF.Tests;
+
+public class InitializationTests
+{
+    [SetUp]
+	public void Setup()
+	{
+		CommandRegistry.Reset();
+	}
+
+    [TearDown]
+	public void TearDown()
+	{
+		CommandRegistry.Reset();
+	}
+
+    [Test]
+    public void ScanningInterfaceDoesNotCauseException()
+    {
+        Assert.DoesNotThrow(ScanAssemblyContainingInterface);
+    }
+
+    private void ScanAssemblyContainingInterface()
+    {
+        CommandRegistry.RegisterAll(AssemblyContainingInterface());
+    }
+
+    private Assembly AssemblyContainingInterface()
+    {
+        var mockAssembly = A.Fake<Assembly>();
+        A.CallTo(() => mockAssembly.GetTypes()).Returns(new Type[]{
+            typeof(ISomeInterface),
+        });
+        return mockAssembly;
+    }
+
+    private interface ISomeInterface;
+
+}

--- a/VCF.Tests/InitializationTests.cs
+++ b/VCF.Tests/InitializationTests.cs
@@ -7,38 +7,38 @@ namespace VCF.Tests;
 
 public class InitializationTests
 {
-    [SetUp]
+	[SetUp]
 	public void Setup()
 	{
 		CommandRegistry.Reset();
 	}
 
-    [TearDown]
+	[TearDown]
 	public void TearDown()
 	{
 		CommandRegistry.Reset();
 	}
 
-    [Test]
-    public void ScanningInterfaceDoesNotCauseException()
-    {
-        Assert.DoesNotThrow(ScanAssemblyContainingInterface);
-    }
+	[Test]
+	public void ScanningInterfaceDoesNotCauseException()
+	{
+		Assert.DoesNotThrow(ScanAssemblyContainingInterface);
+	}
 
-    private void ScanAssemblyContainingInterface()
-    {
-        CommandRegistry.RegisterAll(AssemblyContainingInterface());
-    }
+	private void ScanAssemblyContainingInterface()
+	{
+		CommandRegistry.RegisterAll(AssemblyContainingInterface());
+	}
 
-    private Assembly AssemblyContainingInterface()
-    {
-        var mockAssembly = A.Fake<Assembly>();
-        A.CallTo(() => mockAssembly.GetTypes()).Returns(new Type[]{
-            typeof(ISomeInterface),
-        });
-        return mockAssembly;
-    }
+	private Assembly AssemblyContainingInterface()
+	{
+		var mockAssembly = A.Fake<Assembly>();
+		A.CallTo(() => mockAssembly.GetTypes()).Returns(new Type[]{
+			typeof(ISomeInterface),
+		});
+		return mockAssembly;
+	}
 
-    private interface ISomeInterface;
+	private interface ISomeInterface;
 
 }

--- a/VCF.Tests/InitializationTests.cs
+++ b/VCF.Tests/InitializationTests.cs
@@ -39,6 +39,9 @@ public class InitializationTests
 		return mockAssembly;
 	}
 
-	private interface ISomeInterface;
+	private interface ISomeInterface
+	{
+
+	}
 
 }


### PR DESCRIPTION
resolves issue: https://github.com/decaprime/VampireCommandFramework/issues/19

additionally:
- adds nuget.org as a package source (project wouldn't build for me without this)
- adjusts some assertions so tests can pass on Windows (LF vs CRLF line endings)
