### PR TITLE
🚸 Better support quoted strings and escaped quotes in strings

### DIFF
--- a/VCF.Core/VCF.Core.csproj
+++ b/VCF.Core/VCF.Core.csproj
@@ -20,10 +20,10 @@
 		<Copy SourceFiles="$(OutDir)\VampireCommandFramework.dll" DestinationFolder="$(SolutionDir)/dist" />
 	</Target>
 	<ItemGroup>
-		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.668" IncludeAssets="compile" />
-		<PackageReference Include="BepInEx.Core" Version="6.0.0-be.668" IncludeAssets="compile" />
+		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.690" IncludeAssets="compile" />
+		<PackageReference Include="BepInEx.Core" Version="6.0.0-be.690" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-		<PackageReference Include="VRising.Unhollowed.Client" Version="1.0.0.*" />
+		<PackageReference Include="VRising.Unhollowed.Client" Version="1.0.*" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
 	</ItemGroup>
 

--- a/VCF.SimpleSamplePlugin/VCF.SimpleSamplePlugin.csproj
+++ b/VCF.SimpleSamplePlugin/VCF.SimpleSamplePlugin.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-		<PackageReference Include="VRising.Unhollowed.Client" Version="1.0.0.*" />
+		<PackageReference Include="VRising.Unhollowed.Client" Version="1.0.*" />
 		<PackageReference Include="Vrising.Bloodstone" Version="0.1.*" />
 	</ItemGroup>
 	<ItemGroup>

--- a/VCF.Tests/GetPartsTests.cs
+++ b/VCF.Tests/GetPartsTests.cs
@@ -6,22 +6,72 @@ namespace VCF.Tests;
 public class GetPartsTests
 {
 	[Test]
-	public void GetParts_No_Quotes()
+	public void GetParts_Empty()
 	{
 		var empty = Array.Empty<string>();
-		Assert.That(Utility.GetParts("blah blah"), Is.EqualTo(new[] { "blah", "blah" }));
 		Assert.That(Utility.GetParts(""), Is.EqualTo(empty));
 		Assert.That(Utility.GetParts(" "), Is.EqualTo(empty));
+		Assert.That(Utility.GetParts(null), Is.EqualTo(empty));
+	}
+
+	[Test]
+	public void GetParts_No_Quotes()
+	{
+		Assert.That(Utility.GetParts("blah blah"), Is.EqualTo(new[] { "blah", "blah" }));
 		Assert.That(Utility.GetParts("a "), Is.EqualTo(new[] { "a" }));
 		Assert.That(Utility.GetParts(" a"), Is.EqualTo(new[] { "a" }));
 		Assert.That(Utility.GetParts(" a  b    c "), Is.EqualTo(new[] { "a", "b", "c" }));
 	}
 
 	[Test]
-	public void GetParts_Quotes()
+	public void GetParts_Quotes_Preserves_Spacing()
 	{
-		Assert.That(Utility.GetParts("a \"b c\""), Is.EqualTo(new[] { "a", "b c" }));
-		// TODO: Consider if this should be the result, it fails now
-		//	Assert.That(CommandRegistry.GetParts(" a  \" b    c \""), Is.EqualTo(new[] { "a", " b    c " }));
+		Assert.That(Utility.GetParts(" a  \" b    c \""), Is.EqualTo(new[] { "a", " b    c " }));
+	}
+
+	[Test]
+	public void GetParts_Quotes_Many()
+	{
+		Assert.That(Utility.GetParts(" \"a\" \" b    c \" not  quoted "), Is.EqualTo(new[] { "a", " b    c ", "not", "quoted" }));
+	}
+
+	[Test]
+	public void GetParts_Quote_SingleTerm()
+	{
+		Assert.That(Utility.GetParts("a"), Is.EqualTo(new[] { "a" }));
+		Assert.That(Utility.GetParts("\"a\""), Is.EqualTo(new[] { "a" }));
+		Assert.That(Utility.GetParts("\"abc\""), Is.EqualTo(new[] { "abc" }));
+	}
+
+	[Test]
+	public void GetParts_Quote_SingleTerm_Positional()
+	{
+		Assert.That(Utility.GetParts("a \"b\" c"), Is.EqualTo(new[] { "a", "b", "c" }));
+		Assert.That(Utility.GetParts("\"a\" b c"), Is.EqualTo(new[] { "a", "b", "c" }));
+		Assert.That(Utility.GetParts("a b \"c\""), Is.EqualTo(new[] { "a", "b", "c" }));
+	}
+
+	[Test]
+	public void GetParts_Escape_Quotes()
+	{
+		Assert.That(Utility.GetParts("\"I'm like \\\"O'rly?\\\", they're like \\\"ya rly\\\"\""), Is.EqualTo(new[] { "I'm like \"O'rly?\", they're like \"ya rly\"" }));
+		Assert.That(Utility.GetParts(@"a\b\\""c\"""), Is.EqualTo(new[] { @"a\b\""c""" }));
+	}
+
+	[Test]
+	public void GetParts_Escape_Slashliteral()
+	{
+		Assert.That(Utility.GetParts(@"\"), Is.EqualTo(new[] { @"\" }));
+		Assert.That(Utility.GetParts(@"\\\"), Is.EqualTo(new[] { @"\\\" }));
+
+		Assert.That(Utility.GetParts("\\a"), Is.EqualTo(new[] { "\\a" }));
+		Assert.That(Utility.GetParts("\\\""), Is.EqualTo(new[] { "\"" }));
+	}
+
+	[Test]
+	public void GetParts_Escape_Grouping()
+	{	
+		Assert.That(Utility.GetParts(@"\ \"), Is.EqualTo(new[] { @"\", @"\" }));
+		Assert.That(Utility.GetParts(@"a\b  \  c"), Is.EqualTo(new[] { @"a\b", @"\", "c" }));
 	}
 }


### PR DESCRIPTION
This addresses how input command strings are split into parts, considering a command like

 ```csharp
[Command("cmd")] void F(ICommandContext x, string arg)
```

1. Addresses #22 so `.cmd "a"` now passes `a` for arg
2. Add literal spacing to strings so `.cmd "  a       b "` now passes `  a       b ` for arg
3. Add escapes `\` to strings so `.cmd "hey \"pal\""` now passes `hey "pal"` for arg

I'm unsure if this could break any existing commands, or misses some edge case, but I think it moves the user experience forward. Overall the test suite has more coverage and I tested E2E with a plugin.
