### PR TITLE
Fixes for 1.1

### DIFF
--- a/VCF.Core/Basics/RoleMiddleware.cs
+++ b/VCF.Core/Basics/RoleMiddleware.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/VCF.Core/Breadstone/VWorld.cs
+++ b/VCF.Core/Breadstone/VWorld.cs
@@ -1,5 +1,6 @@
 ﻿using ProjectM;
 using ProjectM.Network;
+using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -12,7 +13,8 @@ internal static class VWorld
 {
 	public static void SendSystemMessage(this User user, string message)
 	{
-		ServerChatUtils.SendSystemMessageToClient(Server.EntityManager, user, message);
+		FixedString512Bytes unityMessage = message;
+		ServerChatUtils.SendSystemMessageToClient(Server.EntityManager, user, ref unityMessage);
 	}
 
 	private static World _serverWorld;

--- a/VCF.Core/Common/Utility.cs
+++ b/VCF.Core/Common/Utility.cs
@@ -1,7 +1,5 @@
-﻿using RootMotion.FinalIK;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace VampireCommandFramework.Common;

--- a/VCF.Core/Framework/ChatCommandContext.cs
+++ b/VCF.Core/Framework/ChatCommandContext.cs
@@ -1,6 +1,8 @@
-﻿using ProjectM;
+﻿using Engine.Console;
+using ProjectM;
 using ProjectM.Network;
 using System;
+using Unity.Collections;
 using VampireCommandFramework.Breadstone;
 
 namespace VampireCommandFramework;
@@ -44,9 +46,11 @@ public class ChatCommandContext : ICommandContext
 	static int maxMessageLength = 509;
 	public void Reply(string v)
 	{
-		if(v.Length > maxMessageLength)
+		if (v.Length > maxMessageLength)
 		 	v = v[..maxMessageLength];
-		ServerChatUtils.SendSystemMessageToClient(VWorld.Server.EntityManager, User, v);
+
+		FixedString512Bytes unityMessage = v;
+		ServerChatUtils.SendSystemMessageToClient(VWorld.Server.EntityManager, User, ref unityMessage);
 	}
 
 	// todo: expand this, just throw from here as void and build a handler that can message user/log.

--- a/VCF.Core/Plugin.cs
+++ b/VCF.Core/Plugin.cs
@@ -1,14 +1,6 @@
 ﻿using BepInEx;
-using BepInEx.IL2CPP;
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
-using ProjectM;
-using ProjectM.Audio;
-using System;
-using System.Reflection;
-using Unity.Entities;
-using Unity.Transforms;
-using VampireCommandFramework.Basics;
 
 namespace VampireCommandFramework;
 

--- a/VCF.Core/VCF.Core.csproj
+++ b/VCF.Core/VCF.Core.csproj
@@ -23,8 +23,8 @@
 		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.690" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.Core" Version="6.0.0-be.690" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-		<PackageReference Include="VRising.Unhollowed.Client" Version="1.0.*" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+		<PackageReference Include="VRising.Unhollowed.Client" Version="1.1.*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/VCF.SimpleSamplePlugin/VCF.SimpleSamplePlugin.csproj
+++ b/VCF.SimpleSamplePlugin/VCF.SimpleSamplePlugin.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
 		<PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-		<PackageReference Include="VRising.Unhollowed.Client" Version="1.0.*" />
+		<PackageReference Include="VRising.Unhollowed.Client" Version="1.1.*" />
 		<PackageReference Include="Vrising.Bloodstone" Version="0.1.*" />
 	</ItemGroup>
 	<ItemGroup>

--- a/VCF.Tests/CommandArgumentConverterTests.cs
+++ b/VCF.Tests/CommandArgumentConverterTests.cs
@@ -1,7 +1,6 @@
 ﻿using FakeItEasy;
 using NUnit.Framework;
 using VampireCommandFramework;
-using VampireCommandFramework.Basics;
 
 namespace VCF.Tests;
 public class CommandArgumentConverterTests

--- a/VCF.Tests/CommandContextTests.cs
+++ b/VCF.Tests/CommandContextTests.cs
@@ -1,13 +1,6 @@
-﻿using FakeItEasy;
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using NUnit.Framework;
 using VampireCommandFramework;
 using VampireCommandFramework.Common;
-using VampireCommandFramework.Registry;
 
 namespace VCF.Tests;
 

--- a/VCF.Tests/HelpTests.cs
+++ b/VCF.Tests/HelpTests.cs
@@ -1,11 +1,6 @@
-﻿using FakeItEasy;
+using FakeItEasy;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using VampireCommandFramework;
 using VampireCommandFramework.Basics;
 using VampireCommandFramework.Registry;

--- a/VCF.Tests/MiddlewareTests.cs
+++ b/VCF.Tests/MiddlewareTests.cs
@@ -1,6 +1,5 @@
-using Consumer;
-using NUnit.Framework;
 using FakeItEasy;
+using NUnit.Framework;
 using System.Reflection;
 using VampireCommandFramework;
 

--- a/VCF.Tests/OverloadTests.cs
+++ b/VCF.Tests/OverloadTests.cs
@@ -1,7 +1,5 @@
-﻿using FakeItEasy;
 using NUnit.Framework;
 using VampireCommandFramework;
-using VampireCommandFramework.Registry;
 
 namespace VCF.Tests;
 

--- a/VCF.Tests/ParsingTests.cs
+++ b/VCF.Tests/ParsingTests.cs
@@ -1,7 +1,6 @@
 using Consumer;
-using NUnit.Framework;
 using FakeItEasy;
-using VampireCommandFramework.Registry;
+using NUnit.Framework;
 using VampireCommandFramework;
 
 namespace VCF.Tests;

--- a/VCF.Tests/StaticCommandsTests.cs
+++ b/VCF.Tests/StaticCommandsTests.cs
@@ -1,7 +1,6 @@
 ﻿using FakeItEasy;
 using NUnit.Framework;
 using VampireCommandFramework;
-using VampireCommandFramework.Registry;
 
 namespace VCF.Tests;
 


### PR DESCRIPTION
This allows VCF to work in 1.1 and cleans up some usings.

The main fix is with SendSystemMessageToClient now takes a FixedString512Bytes by reference instead of a string for the message.