### PR TITLE
Commands are Case Insensitive

### DIFF
--- a/VCF.Core/Registry/CommandCache.cs
+++ b/VCF.Core/Registry/CommandCache.cs
@@ -14,6 +14,8 @@ internal class CommandCache
 
 	internal void AddCommand(string key, ParameterInfo[] parameters, CommandMetadata command)
 	{
+		key = key.ToLowerInvariant();
+
 		var p = parameters.Length;
 		var d = parameters.Where(p => p.HasDefaultValue).Count();
 		if (!_newCache.ContainsKey(key))
@@ -41,15 +43,16 @@ internal class CommandCache
 
 	internal CacheResult GetCommand(string rawInput)
 	{
+		var lowerRawInput = rawInput.ToLowerInvariant();
 		// todo: I think allows for overlap between .foo "bar" and .foo bar <no parameters>
 		List<CommandMetadata> possibleMatches = new();
 		foreach (var (key, argCounts) in _newCache)
 		{
-			if (rawInput.StartsWith(key))
+			if (lowerRawInput.StartsWith(key))
 			{
 				// there's no need to inspect the parameters if the next character isn't a space or the end of the string
 				// because it means that this was part of a different prefix token
-				if (rawInput.Length > key.Length && rawInput[key.Length] != ' ')
+				if (lowerRawInput.Length > key.Length && lowerRawInput[key.Length] != ' ')
 				{
 					continue;
 				}

--- a/VCF.Tests/CaseSensitivityTests.cs
+++ b/VCF.Tests/CaseSensitivityTests.cs
@@ -1,0 +1,53 @@
+﻿using FakeItEasy;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VampireCommandFramework;
+
+namespace VCF.Tests;
+public class CaseSensitivityTests
+{
+	static string? passedArgument;
+
+	class CaseSensitivityTestCommands
+	{
+		[Command("test")]
+		public void TestCommand(ICommandContext ctx) { }
+
+		[Command("testUPPER")]
+		public void TestWithefault(ICommandContext ctx) { }
+
+		[Command("testStringArgument")]
+		public void TestStringArgument(ICommandContext ctx, string arg) { passedArgument = arg; }
+	}
+
+	[SetUp]
+	public void Setup()
+	{
+		CommandRegistry.Reset();
+		CommandRegistry.RegisterCommandType(typeof(CaseSensitivityTestCommands));
+		passedArgument = null;
+	}
+
+	[Test]
+	public void CanUseUpperCase()
+	{
+		Assert.That(CommandRegistry.Handle(A.Fake<ICommandContext>(), ".tEsT"), Is.EqualTo(CommandResult.Success));
+	}
+
+	[Test]
+	public void CanCallUpperCaseCommandWithLowerCase()
+	{
+		Assert.That(CommandRegistry.Handle(A.Fake<ICommandContext>(), ".testupper"), Is.EqualTo(CommandResult.Success));
+	}
+
+	[Test]
+	public void StringArgumentKeepsCase()
+	{
+		Assert.That(CommandRegistry.Handle(A.Fake<ICommandContext>(), ".teststringargument CaseSensitivity"), Is.EqualTo(CommandResult.Success));
+		Assert.That(passedArgument, Is.EqualTo("CaseSensitivity"));
+	}
+}


### PR DESCRIPTION
Adds case insensitivity to selecting commands for matches and unit tests to validate.