### PR TITLE
Help by Plugin

### DIFF
--- a/VCF.Tests/AssertReplyContext.cs
+++ b/VCF.Tests/AssertReplyContext.cs
@@ -32,6 +32,11 @@ public class AssertReplyContext : ICommandContext
 		var repliedText = RepliedTextLfAndTrimmed();
 		Assert.That(repliedText.Contains(expected), Is.True, $"Expected {expected} to be contained in replied: {repliedText}");
 	}
+	public void AssertReplyDoesntContain(string expected)
+	{
+		var repliedText = RepliedTextLfAndTrimmed();
+		Assert.That(repliedText.Contains(expected), Is.False, $"Expected {expected} to not be contained in replied: {repliedText}");
+	}
 
 	public void AssertInternalError()
 	{


### PR DESCRIPTION
### IGNORE THIS ONE

In order to reduce the clutter when trying to find help on commands, help now initially only returns all the plugins that have registered commands that the user is able to use.  Calling `.help <pluginName>` returns back all the commands for that plugin and can add one additional filter to search within the commands of that plugin.  As well, the commands and plugins are sorted.  Adding in the command `.help-all [<filter.]` which functions pretty much same as the old .help.


**Note don't merge this actually into commands are case insensitive but should go into main after that PR is approved and rebased**