### PR TITLE
Commands can now be overloaded.

### DIFF
--- a/VCF.Core/Basics/HelpCommand.cs
+++ b/VCF.Core/Basics/HelpCommand.cs
@@ -77,7 +77,7 @@ internal static class HelpCommands
 		void GenerateFullHelp(CommandMetadata command, List<string> aliases, StringBuilder sb)
 		{
 			sb.AppendLine($"{B(command.Attribute.Name)} ({command.Attribute.Id}) {command.Attribute.Description}");
-			sb.AppendLine(PrintShortHelp(command));
+			sb.AppendLine(GetShortHelp(command));
 			sb.AppendLine($"{B("Aliases").Underline()}: {string.Join(", ", aliases).Italic()}");
 
 			// Automatically Display Enum types
@@ -112,7 +112,7 @@ internal static class HelpCommands
 		var foundAnything = false;
 		foreach (var assembly in CommandRegistry.AssemblyCommandMap.Where(x => x.Value.Keys.Any(c => CommandRegistry.CanCommandExecute(ctx, c) &&
 																										 (filter == null ||
-																										  PrintShortHelp(c).Contains(filter, StringComparison.InvariantCultureIgnoreCase)))))
+																										  GetShortHelp(c).Contains(filter, StringComparison.InvariantCultureIgnoreCase)))))
 		{
 			PrintAssemblyHelp(ctx, assembly, sb, filter);
 			foundAnything = true;
@@ -134,13 +134,13 @@ internal static class HelpCommands
 
 		foreach (var command in commands.OrderBy(c => (c.GroupAttribute != null ? c.GroupAttribute.Name + " " : "") + c.Attribute.Name))
 		{
-			var helpLine = PrintShortHelp(command);
+			var helpLine = GetShortHelp(command);
 			if (filter == null || helpLine.Contains(filter, StringComparison.InvariantCultureIgnoreCase))
 				sb.AppendLine(helpLine);
 		}
 	}
 
-	internal static string PrintShortHelp(CommandMetadata command)
+	internal static string GetShortHelp(CommandMetadata command)
 	{
 		var attr = command.Attribute;
 		var groupPrefix = string.IsNullOrEmpty(command.GroupAttribute?.Name) ? string.Empty : $"{command.GroupAttribute.Name} ";

--- a/VCF.Core/Framework/Color.cs
+++ b/VCF.Core/Framework/Color.cs
@@ -11,4 +11,5 @@ public static class Color
 	public static string LightGrey = "#ccc";
 	public static string Yellow = "#dd0";
 	public static string DarkGreen = "#0c0";
+	public static string Command = "#40E0D0";
 }

--- a/VCF.Core/Registry/CacheResult.cs
+++ b/VCF.Core/Registry/CacheResult.cs
@@ -1,10 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace VampireCommandFramework.Registry;
 
-internal record CacheResult(CommandMetadata Command, string[] Args, IEnumerable<CommandMetadata> PartialMatches)
+internal record CacheResult
 {
-	internal bool IsMatched => Command != null;
+	internal IEnumerable<CommandMetadata> Commands { get; }
+	internal string[] Args { get; }
+	internal IEnumerable<CommandMetadata> PartialMatches { get; }
+
+	internal bool IsMatched => Commands != null && Commands.Any();
 	internal bool HasPartial => PartialMatches?.Any() ?? false;
+
+	// Constructor for multiple commands
+	public CacheResult(IEnumerable<CommandMetadata> commands, string[] args, IEnumerable<CommandMetadata> partialMatches)
+	{
+		Commands = commands;
+		Args = args ?? Array.Empty<string>(); // Ensure Args is never null
+		PartialMatches = partialMatches;
+	}
+
+	// Constructor for single command or null
+	public CacheResult(CommandMetadata command, string[] args, IEnumerable<CommandMetadata> partialMatches)
+	{
+		Commands = command != null ? new[] { command } : null;
+		Args = args ?? Array.Empty<string>(); // Ensure Args is never null
+		PartialMatches = partialMatches;
+	}
 }

--- a/VCF.Core/Registry/CommandMetadata.cs
+++ b/VCF.Core/Registry/CommandMetadata.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 
 namespace VampireCommandFramework.Registry;
 
-internal record CommandMetadata(CommandAttribute Attribute, MethodInfo Method, ConstructorInfo Constructor, ParameterInfo[] Parameters, Type ContextType, Type ConstructorType, CommandGroupAttribute GroupAttribute);
+internal record CommandMetadata(CommandAttribute Attribute, Assembly Assembly, MethodInfo Method, ConstructorInfo Constructor, ParameterInfo[] Parameters, Type ContextType, Type ConstructorType, CommandGroupAttribute GroupAttribute);

--- a/VCF.Core/Registry/CommandRegistry.cs
+++ b/VCF.Core/Registry/CommandRegistry.cs
@@ -3,19 +3,23 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using VampireCommandFramework.Basics;
 using VampireCommandFramework.Common;
 using VampireCommandFramework.Registry;
+
+using static VampireCommandFramework.Format;
 
 namespace VampireCommandFramework;
 
 public static class CommandRegistry
 {
 	internal const string DEFAULT_PREFIX = ".";
-	private static CommandCache _cache = new();
+	internal static CommandCache _cache = new();
 	/// <summary>
 	/// From converting type to (object instance, MethodInfo tryParse, Type contextType)
 	/// </summary>
-	internal static Dictionary<Type, (object instance, MethodInfo tryParse, Type contextType)> _converters = new();
+	internal static Dictionary<Type, (object instance, MethodInfo tryParse, Type contextType)> _converters = [];
 
 	internal static void Reset()
 	{
@@ -30,6 +34,9 @@ public static class CommandRegistry
 	// todo: document this default behavior, it's just not something to ship without but you can Middlewares.Claer();
 	private static List<CommandMiddleware> DEFAULT_MIDDLEWARES = new() { new VCF.Core.Basics.BasicAdminCheck() };
 	public static List<CommandMiddleware> Middlewares { get; } = new() { new VCF.Core.Basics.BasicAdminCheck() };
+
+	// Store pending commands for selection
+	private static Dictionary<string, List<(CommandMetadata Command, object[] Args, string Error)>> _pendingCommands = [];
 
 	internal static bool CanCommandExecute(ICommandContext ctx, CommandMetadata command)
 	{
@@ -53,38 +60,326 @@ public static class CommandRegistry
 		return true;
 	}
 
+	private static void HandleBeforeExecute(ICommandContext ctx, CommandMetadata command)
+	{
+		Middlewares.ForEach(m => m.BeforeExecute(ctx, command.Attribute, command.Method));
+	}
+
+	private static void HandleAfterExecute(ICommandContext ctx, CommandMetadata command)
+	{
+		Middlewares.ForEach(m => m.AfterExecute(ctx, command.Attribute, command.Method));
+	}
+
 	public static CommandResult Handle(ICommandContext ctx, string input)
 	{
-
-
-		// todo: rethink, maybe you only want 1 door here, people will confuse these and it's probably possible to collapse
-		static void HandleBeforeExecute(ICommandContext ctx, CommandMetadata command)
+		// Check if this is a command selection (e.g., .1, .2, etc.)
+		if (input.StartsWith(DEFAULT_PREFIX) && input.Length > 1)
 		{
-			Middlewares.ForEach(m => m.BeforeExecute(ctx, command.Attribute, command.Method));
+			string numberPart = input.Substring(1);
+			if (int.TryParse(numberPart, out int selectedIndex) && selectedIndex > 0)
+			{
+				return HandleCommandSelection(ctx, selectedIndex);
+			}
 		}
 
-		static void HandleAfterExecute(ICommandContext ctx, CommandMetadata command)
+		// Ensure the command starts with the prefix
+		if (!input.StartsWith(DEFAULT_PREFIX))
 		{
-			Middlewares.ForEach(m => m.AfterExecute(ctx, command.Attribute, command.Method));
+			return CommandResult.Unmatched; // Not a command
 		}
 
+		// Remove the prefix for processing
+		string afterPrefix = input.Substring(DEFAULT_PREFIX.Length);
 
-		var matchedCommand = _cache.GetCommand(input);
-		var (command, args) = (matchedCommand.Command, matchedCommand.Args);
+		// Check if this could be an assembly-specific command
+		string assemblyName = null;
+		string commandInput = input; // Default to using the entire input
+
+		int spaceIndex = afterPrefix.IndexOf(' ');
+		if (spaceIndex > 0)
+		{
+			string potentialAssemblyName = afterPrefix.Substring(0, spaceIndex);
+
+			// Check if this could be a valid assembly name
+			bool isValidAssembly = AssemblyCommandMap.Keys.Any(a =>
+				a.GetName().Name.Equals(potentialAssemblyName, StringComparison.OrdinalIgnoreCase));
+
+			if (isValidAssembly)
+			{
+				assemblyName = potentialAssemblyName;
+				commandInput = "." + afterPrefix.Substring(spaceIndex + 1);
+			}
+		}
+
+		// Get command(s) based on input
+		CacheResult matchedCommand;
+		if (assemblyName != null)
+		{
+			matchedCommand = _cache.GetCommandFromAssembly(commandInput, assemblyName);
+		}
+		else
+		{
+			matchedCommand = _cache.GetCommand(input);
+		}
+
+		var (commands, args) = (matchedCommand.Commands, matchedCommand.Args);
 
 		if (!matchedCommand.IsMatched)
 		{
 			if (!matchedCommand.HasPartial) return CommandResult.Unmatched; // NOT FOUND
 
-
 			foreach (var possible in matchedCommand.PartialMatches)
 			{
-				ctx.SysReply(Basics.HelpCommands.PrintShortHelp(possible));
+				ctx.SysReply(HelpCommands.GetShortHelp(possible));
 			}
 
 			return CommandResult.UsageError;
 		}
 
+		// If there's only one command, handle it directly
+		if (commands.Count() == 1)
+		{
+			return ExecuteCommand(ctx, commands.First(), args);
+		}
+
+		// Multiple commands match, try to convert parameters for each
+		var successfulCommands = new List<(CommandMetadata Command, object[] Args, string Error)>();
+		var failedCommands = new List<(CommandMetadata Command, string Error)>();
+
+		foreach (var command in commands)
+		{
+			if (!CanCommandExecute(ctx, command)) continue;
+
+			var (success, commandArgs, error) = TryConvertParameters(ctx, command, args);
+			if (success)
+			{
+				successfulCommands.Add((command, commandArgs, null));
+			}
+			else
+			{
+				failedCommands.Add((command, error));
+			}
+		}
+
+		// Case 1: No command succeeded
+		if (successfulCommands.Count == 0)
+		{
+			ctx.Reply($"{"[error]".Color(Color.Red)} Failed to execute command due to parameter conversion errors:");
+			foreach (var (command, error) in failedCommands)
+			{
+				string assemblyInfo = command.Assembly.GetName().Name;
+				ctx.Reply($"  - {command.Attribute.Id} ({assemblyInfo}): {error}");
+			}
+			return CommandResult.UsageError;
+		}
+
+		// Case 2: Only one command succeeded
+		if (successfulCommands.Count == 1)
+		{
+			var (command, commandArgs, _) = successfulCommands[0];
+			return ExecuteCommandWithArgs(ctx, command, commandArgs);
+		}
+
+		// Case 3: Multiple commands succeeded - store and ask user to select
+		_pendingCommands[ctx.Name] = successfulCommands;
+
+		var sb = new StringBuilder();
+		sb.AppendLine($"Multiple commands match this input. Select one by typing {B(".<#>").Color(Color.Command)}:");
+		for (int i = 0; i < successfulCommands.Count; i++)
+		{
+			var (command, _, _) = successfulCommands[i];
+			var cmdAssembly = command.Assembly.GetName().Name;
+			var description = command.Attribute.Description;
+			sb.AppendLine($" {("."+ (i + 1).ToString()).Color(Color.Command)} - {cmdAssembly.Bold().Color(Color.Primary)} - {B(command.Attribute.Name)} ({command.Attribute.Id}) {command.Attribute.Description}");
+			sb.AppendLine("   " + HelpCommands.GetShortHelp(command));
+		}
+		ctx.SysPaginatedReply(sb);
+
+		return CommandResult.Success;
+	}
+
+	// Add these helper methods:
+
+	private static CommandResult HandleCommandSelection(ICommandContext ctx, int selectedIndex)
+	{
+		if (!_pendingCommands.TryGetValue(ctx.Name, out var pendingCommands) || pendingCommands.Count == 0)
+		{
+			ctx.Reply($"{"[error]".Color(Color.Red)} No command selection is pending.");
+			return CommandResult.CommandError;
+		}
+
+		if (selectedIndex < 1 || selectedIndex > pendingCommands.Count)
+		{
+			ctx.Reply($"{"[error]".Color(Color.Red)} Invalid selection. Please select a number between 1 and {pendingCommands.Count}.");
+			return CommandResult.UsageError;
+		}
+
+		var (command, args, _) = pendingCommands[selectedIndex - 1];
+
+		// Clear pending commands after selection
+		var result = ExecuteCommandWithArgs(ctx, command, args);
+		pendingCommands.Clear();
+		return result;
+	}
+
+	private static (bool Success, object[] Args, string Error) TryConvertParameters(ICommandContext ctx, CommandMetadata command, string[] args)
+	{
+		var argCount = args?.Length ?? 0;
+		var paramsCount = command.Parameters.Length;
+		var commandArgs = new object[paramsCount + 1];
+		commandArgs[0] = ctx;
+
+		// Special case for commands with no parameters
+		if (paramsCount == 0 && argCount == 0)
+		{
+			return (true, commandArgs, null);
+		}
+
+		// Handle parameter count mismatch
+		if (argCount > paramsCount)
+		{
+			return (false, null, $"Too many parameters: expected {paramsCount}, got {argCount}");
+		}
+		else if (argCount < paramsCount)
+		{
+			var canDefault = command.Parameters.Skip(argCount).All(p => p.HasDefaultValue);
+			if (!canDefault)
+			{
+				return (false, null, $"Missing required parameters: expected {paramsCount}, got {argCount}");
+			}
+			for (var i = argCount; i < paramsCount; i++)
+			{
+				commandArgs[i + 1] = command.Parameters[i].DefaultValue;
+			}
+		}
+
+		// If we have arguments to convert, process them
+		if (argCount > 0)
+		{
+			for (var i = 0; i < argCount; i++)
+			{
+				var param = command.Parameters[i];
+				var arg = args[i];
+				bool conversionSuccess = false;
+				string conversionError = null;
+
+				try
+				{
+					// Custom Converter
+					if (_converters.TryGetValue(param.ParameterType, out var customConverter))
+					{
+						var (converter, convertMethod, converterContextType) = customConverter;
+
+						// IMPORTANT CHANGE: Return special error code for unassignable context
+						if (!converterContextType.IsAssignableFrom(ctx.GetType()))
+						{
+							// Signal internal error with a special return format
+							return (false, null, $"INTERNAL_ERROR:Converter type {converterContextType.Name} is not assignable from {ctx.GetType().Name}");
+						}
+
+						object result;
+						var tryParseArgs = new object[] { ctx, arg };
+						try
+						{
+							result = convertMethod.Invoke(converter, tryParseArgs);
+							commandArgs[i + 1] = result;
+							conversionSuccess = true;
+						}
+						catch (TargetInvocationException tie)
+						{
+							if (tie.InnerException is CommandException e)
+							{
+								conversionError = $"Parameter {i + 1} ({param.Name}): {e.Message}";
+							}
+							else
+							{
+								conversionError = $"Parameter {i + 1} ({param.Name}): Unexpected error converting parameter";
+							}
+						}
+						catch (Exception)
+						{
+							conversionError = $"Parameter {i + 1} ({param.Name}): Unexpected error converting parameter";
+						}
+					}
+					else
+					{
+						var defaultConverter = TypeDescriptor.GetConverter(param.ParameterType);
+						try
+						{
+							var val = defaultConverter.ConvertFromInvariantString(arg);
+
+							// Separate, more robust enum validation
+							if (param.ParameterType.IsEnum)
+							{
+								bool isDefined = false;
+
+								// For numeric input, we need to check if the value is defined
+								if (int.TryParse(arg, out int enumIntVal))
+								{
+									isDefined = Enum.IsDefined(param.ParameterType, enumIntVal);
+
+									if (!isDefined)
+									{
+										return (false, null, $"Parameter {i + 1} ({param.Name}): Invalid enum value '{arg}' for {param.ParameterType.Name}");
+									}
+								}
+							}
+
+							commandArgs[i + 1] = val;
+							conversionSuccess = true;
+						}
+						catch (Exception e)
+						{
+							conversionError = $"Parameter {i + 1} ({param.Name}): {e.Message}";
+						}
+					}
+				}
+				catch (Exception ex)
+				{
+					conversionError = $"Parameter {i + 1} ({param.Name}): Unexpected error: {ex.Message}";
+				}
+
+				if (!conversionSuccess)
+				{
+					return (false, null, conversionError);
+				}
+			}
+		}
+
+		return (true, commandArgs, null);
+	}
+
+	private static CommandResult ExecuteCommand(ICommandContext ctx, CommandMetadata command, string[] args)
+	{
+		// Handle Context Type not matching command
+		if (!command.ContextType.IsAssignableFrom(ctx?.GetType()))
+		{
+			Log.Warning($"Matched [{command.Attribute.Id}] but can not assign {command.ContextType.Name} from {ctx?.GetType().Name}");
+			return CommandResult.InternalError;
+		}
+
+		// Try to convert parameters
+		var (success, commandArgs, error) = TryConvertParameters(ctx, command, args);
+		if (!success)
+		{
+			// Check for special internal error flag
+			if (error != null && error.StartsWith("INTERNAL_ERROR:"))
+			{
+				string actualError = error.Substring("INTERNAL_ERROR:".Length);
+				Log.Warning(actualError);
+				ctx.InternalError();
+				return CommandResult.InternalError;
+			}
+
+			ctx.Reply($"{"[error]".Color(Color.Red)} {error}");
+			return CommandResult.UsageError;
+		}
+
+		return ExecuteCommandWithArgs(ctx, command, commandArgs);
+	}
+
+	private static CommandResult ExecuteCommandWithArgs(ICommandContext ctx, CommandMetadata command, object[] commandArgs)
+	{
 		// Handle Context Type not matching command
 		if (!command.ContextType.IsAssignableFrom(ctx?.GetType()))
 		{
@@ -98,102 +393,6 @@ public static class CommandRegistry
 			Log.Warning($"Matched [{command.Attribute.Id}] but can not assign {command.ConstructorType.Name} from {ctx?.GetType().Name}");
 			ctx.InternalError();
 			return CommandResult.InternalError;
-		}
-
-		var argCount = args.Length;
-		var paramsCount = command.Parameters.Length;
-		var commandArgs = new object[paramsCount + 1];
-		commandArgs[0] = ctx;
-
-		// Handle default values
-		if (argCount != paramsCount)
-		{
-			var canDefault = command.Parameters.Skip(argCount).All(p => p.HasDefaultValue);
-			if (!canDefault)
-			{
-				// todo: error you bad at defaulting values, how you explain to someone?
-				return CommandResult.UsageError;
-			}
-			for (var i = argCount; i < paramsCount; i++)
-			{
-				commandArgs[i + 1] = command.Parameters[i].DefaultValue;
-			}
-		}
-
-		// Handle Converting Parameters
-		for (var i = 0; i < argCount; i++)
-		{
-			var param = command.Parameters[i];
-			var arg = args[i];
-
-			// Custom Converter
-			if (_converters.TryGetValue(param.ParameterType, out var customConverter))
-			{
-				var (converter, convertMethod, converterContextType) = customConverter;
-
-				if (!converterContextType.IsAssignableFrom(ctx.GetType()))
-				{
-					Log.Error($"Converter type {converterContextType.Name} is not assignable from {ctx.GetType().Name}");
-					ctx.InternalError();
-					return CommandResult.InternalError;
-				}
-
-				object result;
-				var tryParseArgs = new object[] { ctx, arg };
-				try
-				{
-					result = convertMethod.Invoke(converter, tryParseArgs);
-					commandArgs[i + 1] = result;
-				}
-				catch (TargetInvocationException tie)
-				{
-					if (tie.InnerException is CommandException e)
-					{
-						// todo: error matched type but failed to convert arg to type
-						ctx.Reply($"<color=red>[error]</color> Failed converted parameter: {e.Message}");
-						return CommandResult.UsageError;
-					}
-					else
-					{
-						Log.Warning($"Hit unexpected exception {tie}");
-						ctx.InternalError();
-						return CommandResult.InternalError;
-					}
-				}
-				catch (Exception e)
-				{
-					// todo: failed custom converter unhandled
-					Log.Warning($"Hit unexpected exception {e}");
-					ctx.InternalError();
-					return CommandResult.InternalError;
-				}
-			}
-			// Default Converter
-			else
-			{
-				var defaultConverter = TypeDescriptor.GetConverter(param.ParameterType);
-				try
-				{
-					var val = defaultConverter.ConvertFromInvariantString(arg);
-
-					// ensure enums are valid for #16
-					if (defaultConverter is EnumConverter)
-					{
-						if (!Enum.IsDefined(param.ParameterType, val))
-						{
-							ctx.Reply($"<color=red>[error]</color> Invalid value {val} for {param.ParameterType.Name}");
-							return CommandResult.UsageError;
-						}
-					}
-					
-					commandArgs[i + 1] = val;
-				}
-				catch (Exception e)
-				{
-					ctx.Reply($"<color=red>[error]</color> Failed converted parameter: {e.Message}");
-					return CommandResult.UsageError;
-				}
-			}
 		}
 
 		object instance = null;
@@ -222,7 +421,7 @@ public static class CommandRegistry
 		// Handle Middlewares
 		if (!CanCommandExecute(ctx, command))
 		{
-			ctx.Reply($"<color=red>[denied]</color> {command.Attribute.Id}");
+			ctx.Reply($"{"[denied]".Color(Color.Red)} {command.Attribute.Id}");
 			return CommandResult.Denied;
 		}
 
@@ -235,7 +434,7 @@ public static class CommandRegistry
 		}
 		catch (TargetInvocationException tie) when (tie.InnerException is CommandException e)
 		{
-			ctx.Reply($"<color=red>[error]</color> {e.Message}");
+			ctx.Reply($"{"[error]".Color(Color.Red)} {e.Message}");
 			return CommandResult.CommandError;
 		}
 		catch (Exception e)
@@ -403,7 +602,7 @@ public static class CommandRegistry
 
 		var constructorType = customConstructor?.GetParameters().Single().ParameterType;
 
-		var command = new CommandMetadata(commandAttr, method, customConstructor, parameters, first.ParameterType, constructorType, groupAttr);
+		var command = new CommandMetadata(commandAttr, assembly, method, customConstructor, parameters, first.ParameterType, constructorType, groupAttr);
 
 		// todo include prefix and group in here, this shoudl be a string match
 		// todo handle collisons here

--- a/VCF.Tests/AssemblyCommandTests.cs
+++ b/VCF.Tests/AssemblyCommandTests.cs
@@ -1,0 +1,243 @@
+using NUnit.Framework;
+using System.Reflection;
+using System.Collections.Generic;
+using VampireCommandFramework;
+using VampireCommandFramework.Registry;
+using System.Reflection.Emit;
+
+namespace VCF.Tests
+{
+    public class AssemblyCommandTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            CommandRegistry.Reset();
+            Format.Mode = Format.FormatMode.None;
+        }
+
+        #region Test Command Classes
+
+        // Define commands for our mock "MyMod1" assembly
+        public class MyMod1Commands
+        {
+            [Command("test", description: "MyMod1 test command")]
+            public void TestCommand(ICommandContext ctx)
+            {
+                ctx.Reply("MyMod1 test command executed");
+            }
+
+            [Command("echo", description: "MyMod1 echo command")]
+            public void EchoCommand(ICommandContext ctx, string message)
+            {
+                ctx.Reply($"MyMod1 echo: {message}");
+            }
+        }
+
+        // Define commands for our mock "MyMod2" assembly
+        public class MyMod2Commands
+        {
+            [Command("test", description: "MyMod2 test command")]
+            public void TestCommand(ICommandContext ctx)
+            {
+                ctx.Reply("MyMod2 test command executed");
+            }
+
+            [Command("add", description: "MyMod2 add command")]
+            public void AddCommand(ICommandContext ctx, int a, int b)
+            {
+                ctx.Reply($"MyMod2 sum: {a + b}");
+            }
+        }
+
+		#endregion
+
+		#region Helper Methods
+
+		/// <summary>
+		/// Helper method to register commands and associate them with a mock assembly name
+		/// </summary>
+		private void RegisterCommandsWithMockAssembly(System.Type commandType, string mockAssemblyName)
+		{
+			// Register the command type normally
+			CommandRegistry.RegisterCommandType(commandType);
+
+			// Get the actual assembly
+			var realAssembly = commandType.Assembly;
+
+			// Check if commands were registered for the real assembly
+			if (CommandRegistry.AssemblyCommandMap.TryGetValue(realAssembly, out var commandCache))
+			{
+				// Create a dynamic assembly with our mock name
+				var asmName = new AssemblyName(mockAssemblyName);
+				var mockAssembly = AssemblyBuilder.DefineDynamicAssembly(
+					asmName,
+					AssemblyBuilderAccess.Run);
+
+				// Create a new command cache for the mock assembly
+				var mockCommandCache = new Dictionary<CommandMetadata, List<string>>();
+
+				// Create a new command cache for the real assembly (without the commands we're moving)
+				var newRealCommandCache = new Dictionary<CommandMetadata, List<string>>();
+
+				// Sort each command to either the mock or real assembly cache
+				foreach (var entry in commandCache)
+				{
+					if (entry.Key.Method.DeclaringType == commandType)
+					{
+						// This command belongs to the commandType we're registering
+						// Move it to the mock assembly
+						var newCommandMetadata = entry.Key with { Assembly = mockAssembly };
+						mockCommandCache[newCommandMetadata] = entry.Value;
+
+						// Update CommandCache
+						foreach(var cacheEntry in CommandRegistry._cache._newCache.Values)
+						{
+							foreach(var commandList in cacheEntry.Values)
+							{
+								for (int i = 0; i < commandList.Count; i++)
+								{
+									if (commandList[i].Method == entry.Key.Method)
+									{
+										commandList[i] = newCommandMetadata;
+									}
+								}
+							}
+						}
+					}
+					else
+					{
+						// This command belongs to a different type
+						// Keep it in the real assembly
+						newRealCommandCache[entry.Key] = entry.Value;
+					}
+				}
+
+				// Update the registry with our new caches
+				CommandRegistry.AssemblyCommandMap[mockAssembly] = mockCommandCache;
+				CommandRegistry.AssemblyCommandMap[realAssembly] = newRealCommandCache;
+			}
+		}
+
+        #endregion
+
+        #region Tests
+
+        [Test]
+        public void AssemblySpecificCommand_RequiresPrefix()
+        {
+            // Register commands with mock assemblies
+            RegisterCommandsWithMockAssembly(typeof(MyMod1Commands), "MyMod1");
+            RegisterCommandsWithMockAssembly(typeof(MyMod2Commands), "MyMod2");
+
+            var ctx = new AssertReplyContext();
+            
+            // Try without prefix - should fail
+            var result1 = CommandRegistry.Handle(ctx, "MyMod1 test");
+            Assert.That(result1, Is.EqualTo(CommandResult.Unmatched));
+            
+            // Try with prefix - should succeed
+            var result2 = CommandRegistry.Handle(ctx, ".MyMod1 test");
+            Assert.That(result2, Is.EqualTo(CommandResult.Success));
+            ctx.AssertReplyContains("MyMod1 test command executed");
+        }
+        
+        [Test]
+        public void AssemblySpecificCommand_ExecutesCorrectCommand()
+        {
+            // Register commands with mock assemblies
+            RegisterCommandsWithMockAssembly(typeof(MyMod1Commands), "MyMod1");
+            RegisterCommandsWithMockAssembly(typeof(MyMod2Commands), "MyMod2");
+
+            // Test MyMod1 command
+            var ctx1 = new AssertReplyContext();
+            var result1 = CommandRegistry.Handle(ctx1, ".MyMod1 test");
+            Assert.That(result1, Is.EqualTo(CommandResult.Success));
+            ctx1.AssertReplyContains("MyMod1 test command executed");
+            
+            // Test MyMod2 command
+            var ctx2 = new AssertReplyContext();
+            var result2 = CommandRegistry.Handle(ctx2, ".MyMod2 test");
+            Assert.That(result2, Is.EqualTo(CommandResult.Success));
+            ctx2.AssertReplyContains("MyMod2 test command executed");
+		}
+
+		[Test]
+		public void AssemblySpecificCommand_ExecutesAssemblyNameCasing()
+		{
+			// Register commands with mock assemblies
+			RegisterCommandsWithMockAssembly(typeof(MyMod1Commands), "MyMod1");
+			RegisterCommandsWithMockAssembly(typeof(MyMod2Commands), "MyMod2");
+
+			// Test MyMod1 command
+			var ctx1 = new AssertReplyContext();
+			var result1 = CommandRegistry.Handle(ctx1, ".mymod1 test");
+			Assert.That(result1, Is.EqualTo(CommandResult.Success));
+			ctx1.AssertReplyContains("MyMod1 test command executed");
+
+			// Test MyMod2 command
+			var ctx2 = new AssertReplyContext();
+			var result2 = CommandRegistry.Handle(ctx2, ".MYMOD2 test");
+			Assert.That(result2, Is.EqualTo(CommandResult.Success));
+			ctx2.AssertReplyContains("MyMod2 test command executed");
+		}
+
+		[Test]
+        public void AssemblySpecificCommand_WithParameters()
+        {
+            // Register commands with mock assemblies
+            RegisterCommandsWithMockAssembly(typeof(MyMod1Commands), "MyMod1");
+            RegisterCommandsWithMockAssembly(typeof(MyMod2Commands), "MyMod2");
+
+            // Test MyMod1 command with parameter
+            var ctx1 = new AssertReplyContext();
+            var result1 = CommandRegistry.Handle(ctx1, ".MyMod1 echo \"Hello world\"");
+            Assert.That(result1, Is.EqualTo(CommandResult.Success));
+            ctx1.AssertReplyContains("MyMod1 echo: Hello world");
+            
+            // Test MyMod2 command with parameters
+            var ctx2 = new AssertReplyContext();
+            var result2 = CommandRegistry.Handle(ctx2, ".MyMod2 add 10 20");
+            Assert.That(result2, Is.EqualTo(CommandResult.Success));
+            ctx2.AssertReplyContains("MyMod2 sum: 30");
+        }
+        
+        [Test]
+        public void InvalidAssemblyName_FallsBackToRegularCommand()
+        {
+            // Register commands with mock assemblies
+            RegisterCommandsWithMockAssembly(typeof(MyMod1Commands), "MyMod1");
+
+            var ctx = new AssertReplyContext();
+            
+            // Use an invalid assembly name - should try to interpret as a regular command
+            var result = CommandRegistry.Handle(ctx, ".NonExistentMod test hello");
+            
+            Assert.That(result, Is.EqualTo(CommandResult.Unmatched));
+        }
+        
+        [Test]
+        public void SameCommandNameInDifferentAssemblies_UsesCorrectOne()
+        {
+            // Register commands with mock assemblies
+            RegisterCommandsWithMockAssembly(typeof(MyMod1Commands), "MyMod1");
+            RegisterCommandsWithMockAssembly(typeof(MyMod2Commands), "MyMod2");
+
+            // Both assemblies have a 'test' command, but they should be kept separate
+            
+            // Test MyMod1 test command
+            var ctx1 = new AssertReplyContext();
+            var result1 = CommandRegistry.Handle(ctx1, ".MyMod1 test");
+            Assert.That(result1, Is.EqualTo(CommandResult.Success));
+            ctx1.AssertReplyContains("MyMod1 test command executed");
+            
+            // Test MyMod2 test command
+            var ctx2 = new AssertReplyContext();
+            var result2 = CommandRegistry.Handle(ctx2, ".MyMod2 test");
+            Assert.That(result2, Is.EqualTo(CommandResult.Success));
+            ctx2.AssertReplyContains("MyMod2 test command executed");
+        }
+
+        #endregion
+    }
+}

--- a/VCF.Tests/AssertReplyContext.cs
+++ b/VCF.Tests/AssertReplyContext.cs
@@ -32,6 +32,11 @@ public class AssertReplyContext : ICommandContext
 		var repliedText = RepliedTextLfAndTrimmed();
 		Assert.That(repliedText.Contains(expected), Is.True, $"Expected {expected} to be contained in replied: {repliedText}");
 	}
+	public void AssertReplyDoesntContain(string expected)
+	{
+		var repliedText = RepliedTextLfAndTrimmed();
+		Assert.That(repliedText.Contains(expected), Is.False, $"Expected {expected} to not be contained in replied: {repliedText}");
+	}
 
 	public void AssertInternalError()
 	{

--- a/VCF.Tests/CommandAdminAndSelectionTests.cs
+++ b/VCF.Tests/CommandAdminAndSelectionTests.cs
@@ -1,0 +1,245 @@
+using NUnit.Framework;
+using VampireCommandFramework;
+
+namespace VCF.Tests
+{
+    public class CommandAdminAndSelectionTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            CommandRegistry.Reset();
+            Format.Mode = Format.FormatMode.None;
+        }
+
+        #region Test Commands
+
+        // Define admin-only commands
+        public class AdminCommands
+        {
+            [Command("admin", adminOnly: true, description: "Admin-only command")]
+            public void AdminOnly(ICommandContext ctx)
+            {
+                ctx.Reply("Admin command executed");
+            }
+
+            [Command("admin-int", adminOnly: true, description: "Admin-only int command")]
+            public void AdminInt(ICommandContext ctx, int value)
+            {
+                ctx.Reply($"Admin int command executed with: {value}");
+            }
+        }
+
+        // Define regular commands with same name but different params
+        public class RegularCommands
+        {
+            [Command("admin", description: "Regular user command")]
+            public void RegularAdmin(ICommandContext ctx, string value)
+            {
+                ctx.Reply($"Regular command executed with: {value}");
+            }
+
+            [Command("dual")]
+            public void DualCommand(ICommandContext ctx, int value)
+            {
+                ctx.Reply($"Dual int command executed with: {value}");
+            }
+
+            [Command("dual")]
+            public void DualCommand(ICommandContext ctx, float value)
+            {
+                ctx.Reply($"Dual float command executed with: {value}");
+            }
+        }
+
+        #endregion
+
+        #region Admin Access Tests
+
+        [Test]
+        public void AdminCommand_WhenUserIsAdmin_ExecutesCommand()
+        {
+            // Register admin command
+            CommandRegistry.RegisterCommandType(typeof(AdminCommands));
+
+            var ctx = new AssertReplyContext { IsAdmin = true };
+            var result = CommandRegistry.Handle(ctx, ".admin");
+
+            Assert.That(result, Is.EqualTo(CommandResult.Success));
+            ctx.AssertReplyContains("Admin command executed");
+        }
+
+        [Test]
+        public void AdminCommand_WhenUserIsNotAdmin_DeniesAccess()
+        {
+            // Register admin command
+            CommandRegistry.RegisterCommandType(typeof(AdminCommands));
+
+            var ctx = new AssertReplyContext { IsAdmin = false };
+            var result = CommandRegistry.Handle(ctx, ".admin");
+
+            Assert.That(result, Is.EqualTo(CommandResult.Denied));
+            ctx.AssertReplyContains("[denied]");
+        }
+
+        [Test]
+        public void OverloadedCommands_AdminAndRegular_ExecutesCorrectlyBasedOnAccess()
+        {
+            // Register both admin and regular commands
+            CommandRegistry.RegisterCommandType(typeof(AdminCommands));
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // Test non-admin user - should execute regular command
+            var nonAdminCtx = new AssertReplyContext { IsAdmin = false };
+            var nonAdminResult = CommandRegistry.Handle(nonAdminCtx, ".admin test");
+
+            Assert.That(nonAdminResult, Is.EqualTo(CommandResult.Success));
+            nonAdminCtx.AssertReplyContains("Regular command executed with: test");
+
+            // Test admin user - admin command has no params, so should get ambiguity
+            var adminCtx = new AssertReplyContext { IsAdmin = true };
+            var adminResult = CommandRegistry.Handle(adminCtx, ".admin");
+
+            Assert.That(adminResult, Is.EqualTo(CommandResult.Success));
+            adminCtx.AssertReplyContains("Admin command executed");
+        }
+
+        [Test]
+        public void OverloadedCommands_AdminAndRegularWithParams_AdminSelectsCorrectly()
+        {
+            // Register both admin and regular commands
+            CommandRegistry.RegisterCommandType(typeof(AdminCommands));
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // Admin user with a parameter that only matches regular command
+            var adminCtx = new AssertReplyContext { IsAdmin = true };
+            var adminResult = CommandRegistry.Handle(adminCtx, ".admin test");
+
+            Assert.That(adminResult, Is.EqualTo(CommandResult.Success));
+            adminCtx.AssertReplyContains("Regular command executed with: test");
+        }
+
+        [Test]
+        public void OverloadedCommands_AdminInt_AdminCanAccess()
+        {
+            // Register both admin and regular commands
+            CommandRegistry.RegisterCommandType(typeof(AdminCommands));
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // Admin user with int parameter
+            var adminCtx = new AssertReplyContext { IsAdmin = true };
+            var adminResult = CommandRegistry.Handle(adminCtx, ".admin-int 42");
+
+            Assert.That(adminResult, Is.EqualTo(CommandResult.Success));
+            adminCtx.AssertReplyContains("Admin int command executed with: 42");
+        }
+
+        [Test]
+        public void OverloadedCommands_AdminInt_NonAdminCannotAccess()
+        {
+            // Register both admin and regular commands
+            CommandRegistry.RegisterCommandType(typeof(AdminCommands));
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // Non-admin user trying to access admin-int command
+            var nonAdminCtx = new AssertReplyContext { IsAdmin = false };
+            var nonAdminResult = CommandRegistry.Handle(nonAdminCtx, ".admin-int 42");
+
+            Assert.That(nonAdminResult, Is.EqualTo(CommandResult.Denied));
+            nonAdminCtx.AssertReplyContains("[denied]");
+        }
+
+        #endregion
+
+        #region Command Selection Isolation Tests
+
+        [Test]
+        public void CommandSelection_DifferentUsers_IsolatedSelections()
+        {
+            // Register commands that would trigger selection
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // First user gets dual command options
+            var user1 = new AssertReplyContext { Name = "User1" };
+            var result1 = CommandRegistry.Handle(user1, ".dual 42");
+
+            Assert.That(result1, Is.EqualTo(CommandResult.Success));
+            user1.AssertReplyContains("Multiple commands match this input");
+
+            // Second user should not be able to select from first user's options
+            var user2 = new AssertReplyContext { Name = "User2" };
+            var result2 = CommandRegistry.Handle(user2, ".1");
+
+            Assert.That(result2, Is.Not.EqualTo(CommandResult.Success));
+            user2.AssertReplyContains("No command selection is pending");
+        }
+
+        [Test]
+        public void CommandSelection_SameCommandDifferentUsers_IndependentSelections()
+        {
+            // Register commands that would trigger selection
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // First user gets dual command options
+            var user1 = new AssertReplyContext { Name = "User1" };
+            CommandRegistry.Handle(user1, ".dual 42");
+
+            // Second user also gets dual command options
+            var user2 = new AssertReplyContext { Name = "User2" };
+            CommandRegistry.Handle(user2, ".dual 99");
+
+            // First user selects option 1
+            var result1 = CommandRegistry.Handle(user1, ".1");
+            Assert.That(result1, Is.EqualTo(CommandResult.Success));
+            user1.AssertReplyContains("with: 42"); // Should have the original value
+
+            // Second user selects option 1
+            var result2 = CommandRegistry.Handle(user2, ".1");
+            Assert.That(result2, Is.EqualTo(CommandResult.Success));
+            user2.AssertReplyContains("with: 99"); // Should have their own value
+        }
+
+        [Test]
+        public void CommandSelection_DisappearsAfterExecution()
+        {
+            // Register commands that would trigger selection
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // User gets dual command options
+            var user = new AssertReplyContext { Name = "User" };
+            CommandRegistry.Handle(user, ".dual 42");
+
+            // User selects option 1
+            var result1 = CommandRegistry.Handle(user, ".1");
+            Assert.That(result1, Is.EqualTo(CommandResult.Success));
+
+            // Selection should be cleared after execution
+            var result2 = CommandRegistry.Handle(user, ".1");
+            Assert.That(result2, Is.Not.EqualTo(CommandResult.Success));
+            user.AssertReplyContains("No command selection is pending");
+        }
+
+        [Test]
+        public void CommandSelection_InvalidSelection_DoesNotClearOptions()
+        {
+            // Register commands that would trigger selection
+            CommandRegistry.RegisterCommandType(typeof(RegularCommands));
+
+            // User gets dual command options
+            var user = new AssertReplyContext { Name = "User" };
+            CommandRegistry.Handle(user, ".dual 42");
+
+            // User selects invalid option
+            var result1 = CommandRegistry.Handle(user, ".99");
+            Assert.That(result1, Is.EqualTo(CommandResult.UsageError));
+            user.AssertReplyContains("Invalid selection");
+
+            // Selection should still be available
+            var result2 = CommandRegistry.Handle(user, ".1");
+            Assert.That(result2, Is.EqualTo(CommandResult.Success));
+            user.AssertReplyContains("with: 42");
+        }
+
+        #endregion
+    }
+}

--- a/VCF.Tests/CommandOverloadingTests.cs
+++ b/VCF.Tests/CommandOverloadingTests.cs
@@ -1,0 +1,319 @@
+using NUnit.Framework;
+using VampireCommandFramework;
+
+namespace VCF.Tests
+{
+	public class CommandOverloadingTests
+	{
+		[SetUp]
+		public void Setup()
+		{
+			CommandRegistry.Reset();
+			Format.Mode = Format.FormatMode.None;
+		}
+
+		#region Test Commands
+
+		// Define command classes within each test to avoid registration conflicts
+
+		public class StringParameterCommands
+		{
+			[Command("test", description: "String parameter command")]
+			public void TestString(ICommandContext ctx, string value)
+			{
+				ctx.Reply($"String command executed with: {value}");
+			}
+
+			[Command("mixed")]
+			public void MixedParams(ICommandContext ctx, string text, int number)
+			{
+				ctx.Reply($"Mixed command with string: {text}, int: {number}");
+			}
+		}
+
+		public class IntParameterCommands
+		{
+			[Command("test", description: "Int parameter command")]
+			public void TestInt(ICommandContext ctx, int value)
+			{
+				ctx.Reply($"Int command executed with: {value}");
+			}
+
+			[Command("selection")]
+			public void Selection(ICommandContext ctx, int value)
+			{
+				ctx.Reply($"Int selection command with: {value}");
+			}
+		}
+
+		public class FloatParameterCommands
+		{
+			[Command("test", description: "Float parameter command")]
+			public void TestFloat(ICommandContext ctx, float value)
+			{
+				ctx.Reply($"Float command executed with: {value}");
+			}
+
+			[Command("selection")]
+			public void Selection(ICommandContext ctx, float value)
+			{
+				ctx.Reply($"Float selection command with: {value}");
+			}
+		}
+
+		#endregion
+
+		#region Basic Overloading Tests
+
+		[Test]
+		public void OverloadedCommand_StringParameter_ExecutesCorrectCommand()
+		{
+			// Register just string command
+			CommandRegistry.RegisterCommandType(typeof(StringParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".test hello");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("String command executed with: hello");
+		}
+
+		[Test]
+		public void OverloadedCommand_IntParameter_ExecutesCorrectCommand()
+		{
+			// Register just int command
+			CommandRegistry.RegisterCommandType(typeof(IntParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".test 123");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("Int command executed with: 123");
+		}
+
+		[Test]
+		public void OverloadedCommand_FloatParameter_ExecutesCorrectCommand()
+		{
+			// Register just float command
+			CommandRegistry.RegisterCommandType(typeof(FloatParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".test 123.45");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("Float command executed with: 123.45");
+		}
+
+		#endregion
+
+		#region Multiple Valid Commands Tests
+
+		[Test]
+		public void MultipleValidCommands_ShowsSelectionOptions()
+		{
+			// Register both int and float commands
+			CommandRegistry.RegisterCommandType(typeof(IntParameterCommands));
+			CommandRegistry.RegisterCommandType(typeof(FloatParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".selection 42");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("Multiple commands match this input");
+			ctx.AssertReplyContains("selection");
+		}
+
+		[Test]
+		public void CommandSelection_SelectsCorrectCommand()
+		{
+			// Register both command types
+			CommandRegistry.RegisterCommandType(typeof(IntParameterCommands));
+			CommandRegistry.RegisterCommandType(typeof(FloatParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			// First trigger selection
+			CommandRegistry.Handle(ctx, ".selection 42");
+
+			// Now select the first command
+			var result = CommandRegistry.Handle(ctx, ".1");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("selection command with: 42");
+		}
+
+		[Test]
+		public void CommandSelection_InvalidIndex_ReturnsError()
+		{
+			// Register both command types
+			CommandRegistry.RegisterCommandType(typeof(IntParameterCommands));
+			CommandRegistry.RegisterCommandType(typeof(FloatParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			// First trigger selection
+			CommandRegistry.Handle(ctx, ".selection 42");
+
+			// Try an invalid selection
+			var result = CommandRegistry.Handle(ctx, ".99");
+
+			Assert.That(result, Is.EqualTo(CommandResult.UsageError));
+			ctx.AssertReplyContains("Invalid selection");
+		}
+
+		#endregion
+
+		#region Conversion Failure Tests
+
+		// Custom commands for the conversion failure test
+		public class FailingCommandClass
+		{
+			public class CustomType { }
+
+			[Command("failing")]
+			public void FailingCommand(ICommandContext ctx, CustomType value)
+			{
+				// This implementation will never be called
+				ctx.Reply("This shouldn't execute");
+			}
+		}
+
+		[Test]
+		public void ConversionFailure_ShowsError()
+		{
+			CommandRegistry.RegisterCommandType(typeof(FailingCommandClass));
+
+			var ctx = new AssertReplyContext();
+			// Provide a command where no converter exists
+			var result = CommandRegistry.Handle(ctx, ".failing 123");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Unmatched));
+		}
+
+		#endregion
+
+		#region Complex Parameter Tests
+
+		[Test]
+		public void MixedParameterTypes_CorrectlyConverted()
+		{
+			CommandRegistry.RegisterCommandType(typeof(StringParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".mixed hello 42");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("Mixed command with string: hello, int: 42");
+		}
+
+		[Test]
+		public void MixedParameterTypes_ConversionFailure()
+		{
+			CommandRegistry.RegisterCommandType(typeof(StringParameterCommands));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".mixed hello world");
+
+			Assert.That(result, Is.EqualTo(CommandResult.UsageError));
+			ctx.AssertReplyContains("[error]");
+		}
+
+		#endregion
+
+		#region Command Overloading Edge Cases
+
+		public class CommandsWithVaryingParameterCounts
+		{
+			[Command("params")]
+			public void NoParams(ICommandContext ctx)
+			{
+				ctx.Reply("No parameters");
+			}
+
+			[Command("params")]
+			public void OneParam(ICommandContext ctx, int value)
+			{
+				ctx.Reply($"One parameter: {value}");
+			}
+
+			[Command("params")]
+			public void TwoParams(ICommandContext ctx, int a, int b)
+			{
+				ctx.Reply($"Two parameters: {a}, {b}");
+			}
+		}
+
+		[Test]
+		public void DifferentParameterCounts_SelectsCorrectOverload()
+		{
+			CommandRegistry.RegisterCommandType(typeof(CommandsWithVaryingParameterCounts));
+
+			var ctx = new AssertReplyContext();
+
+			// Test with no parameters
+			var result1 = CommandRegistry.Handle(ctx, ".params");
+			Assert.That(result1, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("No parameters");
+
+			// Test with one parameter
+			var ctx2 = new AssertReplyContext();
+			var result2 = CommandRegistry.Handle(ctx2, ".params 42");
+			Assert.That(result2, Is.EqualTo(CommandResult.Success));
+			ctx2.AssertReplyContains("One parameter: 42");
+
+			// Test with two parameters
+			var ctx3 = new AssertReplyContext();
+			var result3 = CommandRegistry.Handle(ctx3, ".params 10 20");
+			Assert.That(result3, Is.EqualTo(CommandResult.Success));
+			ctx3.AssertReplyContains("Two parameters: 10, 20");
+		}
+
+		[Test]
+		public void TooManyParameters_ShowsError()
+		{
+			CommandRegistry.RegisterCommandType(typeof(CommandsWithVaryingParameterCounts));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".params 10 20 30");
+
+			Assert.That(result, Is.EqualTo(CommandResult.UsageError));
+		}
+
+		#endregion
+
+		#region Optional Parameter Tests
+
+		public class CommandsWithOptionalParams
+		{
+			[Command("optional")]
+			public void OptionalParam(ICommandContext ctx, string required, int optional = 42)
+			{
+				ctx.Reply($"Optional command: {required}, {optional}");
+			}
+		}
+
+		[Test]
+		public void OptionalParameters_CanBeOmitted()
+		{
+			CommandRegistry.RegisterCommandType(typeof(CommandsWithOptionalParams));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".optional hello");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("Optional command: hello, 42");
+		}
+
+		[Test]
+		public void OptionalParameters_CanBeProvided()
+		{
+			CommandRegistry.RegisterCommandType(typeof(CommandsWithOptionalParams));
+
+			var ctx = new AssertReplyContext();
+			var result = CommandRegistry.Handle(ctx, ".optional hello 99");
+
+			Assert.That(result, Is.EqualTo(CommandResult.Success));
+			ctx.AssertReplyContains("Optional command: hello, 99");
+		}
+
+		#endregion
+	}
+}

--- a/VCF.Tests/HelpTests.cs
+++ b/VCF.Tests/HelpTests.cs
@@ -154,8 +154,8 @@ public class HelpTests
 	{
 		var (commandName, usage, description) = Any.ThreeStrings();
 
-		var command = new CommandMetadata(new CommandAttribute(commandName, usage: usage, description: description), null, null, null, null, null, null);
-		var text = HelpCommands.PrintShortHelp(command);
+		var command = new CommandMetadata(new CommandAttribute(commandName, null, usage: usage, description: description), null, null, null, null, null, null, null);
+		var text = HelpCommands.GetShortHelp(command);
 		Assert.That(text, Is.EqualTo($".{commandName} {usage}"));
 	}
 
@@ -167,9 +167,9 @@ public class HelpTests
 		var paramName = Any.String();
 		A.CallTo(() => param.Name).Returns(paramName);
 
-		var command = new CommandMetadata(new CommandAttribute(commandName, usage: null, description: description), null, null, new[] { param }, null, null, null);
+		var command = new CommandMetadata(new CommandAttribute(commandName, null, usage: null, description: description), null, null, null, new[] { param }, null, null, null);
 
-		var text = HelpCommands.PrintShortHelp(command);
+		var text = HelpCommands.GetShortHelp(command);
 
 		Assert.That(text, Is.EqualTo($".{commandName} ({paramName})"));
 	}
@@ -185,9 +185,9 @@ public class HelpTests
 		A.CallTo(() => param.DefaultValue).Returns(paramValue);
 		A.CallTo(() => param.HasDefaultValue).Returns(true);
 
-		var command = new CommandMetadata(new CommandAttribute(commandName, usage: null, description: description), null, null, new[] { param }, null, null, null);
+		var command = new CommandMetadata(new CommandAttribute(commandName, usage: null, description: description), null, null, null, new[] { param }, null, null, null);
 
-		var text = HelpCommands.PrintShortHelp(command);
+		var text = HelpCommands.GetShortHelp(command);
 
 		Assert.That(text, Is.EqualTo($".{commandName} [{paramName}={paramValue}]"));
 	}


### PR DESCRIPTION
With the number of commands in plugins and number of plugins out there it's becoming increasingly difficult to not run into conflicts.  This change adds the ability for commands to be overloaded for the same number of parameters by checking the parameters passed against all possible options and seeing which ones will work.  If there is only one option that works then that command is executed.  If there is multiple options that is worked they are all presented to the user numbered with the user then being able to execute them by using `.#` with # replaced with the appropriate number.  Conflicts can as well be resolved beforehand by specifying the plugin name first before the command though you can still have overloading within a single plugin.

A number of unit tests have been added to try to get decent coverage on all the various ways this can be used.  Note had to add assembly to the command metadata in order to be able to properly unit test executing command based on plugin.  Simplifies several retrievals of assembly as well as a result.

**Don't want to PR this into help by plugin but into main after Help by plugin is finished being PRed**