### PR TITLE
Closest command recommendation and updating message presentation

### DIFF
--- a/VCF.Core/Basics/BepInExConfigCommands.cs
+++ b/VCF.Core/Basics/BepInExConfigCommands.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx.IL2CPP;
+using BepInEx.IL2CPP;
 using System;
 using System.Linq;
 using System.Text;
@@ -76,7 +76,7 @@ public class BepInExConfigCommands
 			sb.AppendLine($"[{section.Key}]");
 			foreach (var (def, entry) in section)
 			{
-				sb.AppendLine($"{def.Key.Color(Color.White)} = {entry.BoxedValue.ToString().Color(Color.LightGrey)}");
+				sb.AppendLine($"{def.Key.Color(Color.Beige)} = {entry.BoxedValue.ToString().Color(Color.LightGrey)}");
 			}
 		}
 		ctx.SysPaginatedReply(sb);

--- a/VCF.Core/Basics/HelpCommand.cs
+++ b/VCF.Core/Basics/HelpCommand.cs
@@ -38,6 +38,7 @@ internal static class HelpCommands
 				var individualResults = commands.Where(x =>
 					string.Equals(x.Key.Attribute.Id, search, StringComparison.InvariantCultureIgnoreCase)
 					|| string.Equals(x.Key.Attribute.Name, search, StringComparison.InvariantCultureIgnoreCase)
+					|| (x.Key.GroupAttribute != null && string.Equals(x.Key.GroupAttribute.Name, search, StringComparison.InvariantCultureIgnoreCase))
 					|| x.Value.Contains(search, StringComparer.InvariantCultureIgnoreCase)
 				);
 
@@ -47,7 +48,7 @@ internal static class HelpCommands
 
 				if (!individualResults.Any())
 				{
-					throw ctx.Error($"Could not find any commands for \"{search}\"");
+					throw ctx.Error($"Could not find any commands for \"{search.Color(Color.Gold)}\"");
 				}
 
 				var sb = new StringBuilder();
@@ -63,28 +64,28 @@ internal static class HelpCommands
 		{
 			var sb = new StringBuilder();
 			sb.AppendLine($"Listing {B("all")} plugins");
-			sb.AppendLine($"Use {B(".help <plugin>")} for commands in that plugin");
+			sb.AppendLine($"Use {B(".help <plugin>").Color(Color.Gold)} for commands in that plugin");
 			// List all plugins they have a command they can execute for
 			foreach (var assemblyName in CommandRegistry.AssemblyCommandMap.Where(x => x.Value.Keys.Any(c => CommandRegistry.CanCommandExecute(ctx, c)))
 																		   .Select(x => x.Key.GetName().Name)
 																		   .OrderBy(x => x))
 			{
-				sb.AppendLine($"{assemblyName}");
+				sb.AppendLine($"{assemblyName.Color(Color.Lilac)}");
 			}
 			ctx.SysPaginatedReply(sb);
 		}
 
 		void GenerateFullHelp(CommandMetadata command, List<string> aliases, StringBuilder sb)
 		{
-			sb.AppendLine($"{B(command.Attribute.Name)} ({command.Attribute.Id}) {command.Attribute.Description}");
+			sb.AppendLine($"{B(command.Attribute.Name).Color(Color.LightRed)} {command.Attribute.Description.Color(Color.Grey)}");
 			sb.AppendLine(GetShortHelp(command));
-			sb.AppendLine($"{B("Aliases").Underline()}: {string.Join(", ", aliases).Italic()}");
+			sb.AppendLine($"{B("Aliases").Underline().Color(Color.Pink)}: {string.Join(", ", aliases).Italic()}");
 
 			// Automatically Display Enum types
 			var enums = command.Parameters.Select(p => p.ParameterType).Distinct().Where(t => t.IsEnum);
 			foreach (var e in enums)
 			{
-				sb.AppendLine($"{Format.Bold($"{e.Name} Values").Underline()}: {string.Join(", ", Enum.GetNames(e))}");
+				sb.AppendLine($"{Format.Bold($"{e.Name} Values").Underline().Color(Color.Pink)}: {string.Join(", ", Enum.GetNames(e)).Color(Color.Command)}");
 			}
 
 			// Check CommandRegistry for types that can be converted and further for IConverterUsage
@@ -150,7 +151,7 @@ internal static class HelpCommands
 		string usageText = GetOrGenerateUsage(command);
 
 		var prefix = CommandRegistry.DEFAULT_PREFIX.Color(Color.Yellow);
-		var commandString = fullCommandName.Color(Color.White);
+		var commandString = fullCommandName.Color(Color.Beige);
 		return $"{prefix}{commandString}{usageText}";
 	}
 

--- a/VCF.Core/Common/Utility.cs
+++ b/VCF.Core/Common/Utility.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -71,7 +71,7 @@ internal static class Utility
 
 	internal static void InternalError(this ICommandContext ctx) => ctx.SysReply("An internal error has occurred.");
 
-	internal static void SysReply(this ICommandContext ctx, string input) => ctx.Reply($"[vcf] ".Color(Color.Primary) + input.Color(Color.White));
+	internal static void SysReply(this ICommandContext ctx, string input) => ctx.Reply($"[vcf] ".Color(Color.Primary) + input.Color(Color.Beige));
 
 	internal static void SysPaginatedReply(this ICommandContext ctx, StringBuilder input) => SysPaginatedReply(ctx, input.ToString());
 
@@ -102,7 +102,7 @@ internal static class Utility
 	{
 		var pages = new List<string>();
 		var page = new StringBuilder();
-		var rawLines = rawText.Split(Environment.NewLine); // todo: does this work on both platofrms?
+		var rawLines = rawText.Split("\n"); // todo: does this work on both platofrms?
 		var lines = new List<string>();
 
 		// process rawLines -> lines of length <= pageSize
@@ -116,7 +116,7 @@ internal static class Utility
 				{
 					// find the last space before the page size within 5% of pageSize buffer
 					var splitIndex = remaining.LastIndexOf(' ', pageSize - (int)(pageSize * 0.05));
-					if (splitIndex < 0)
+					if (splitIndex <= 0)
 					{
 						splitIndex = Math.Min(pageSize - 1, remaining.Length);
 					}

--- a/VCF.Core/Framework/Color.cs
+++ b/VCF.Core/Framework/Color.cs
@@ -6,10 +6,23 @@
 public static class Color
 {
 	public static string Red = "red";
-	public static string Primary = "#b0b";
+	public static string Primary = "#d25";
 	public static string White = "#eee";
-	public static string LightGrey = "#ccc";
+	public static string LightGrey = "#bbf";
 	public static string Yellow = "#dd0";
-	public static string DarkGreen = "#0c0";
-	public static string Command = "#40E0D0";
+	public static string DarkGreen = "#4c4";
+	public static string Command = "#4ED";
+	public static string Beige = "#fed";
+	public static string Gold = "#eb0";
+	public static string Magenta = "#c5d";
+	public static string Pink = "#faf";
+	public static string Purple = "#52d";
+	public static string LightBlue = "#3ac";
+	public static string LightRed = "#f45";
+	public static string LightPurple = "#84c";
+	public static string Lilac = "#b9f";
+	public static string LightPink = "#EED";
+	public static string Grey = "#eef";
+
+
 }

--- a/VCF.Core/Plugin.cs
+++ b/VCF.Core/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
 

--- a/VCF.Tests/CommandArgumentConverterTests.cs
+++ b/VCF.Tests/CommandArgumentConverterTests.cs
@@ -1,4 +1,4 @@
-﻿using FakeItEasy;
+using FakeItEasy;
 using NUnit.Framework;
 using VampireCommandFramework;
 
@@ -38,7 +38,7 @@ public class CommandArgumentConverterTests
 	{
 		public IServiceProvider Services => throw new NotImplementedException();
 
-		public string Name => throw new NotImplementedException();
+		public string Name => "TestName";
 
 		public bool IsAdmin => true;
 

--- a/VCF.Tests/CommandContextTests.cs
+++ b/VCF.Tests/CommandContextTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using VampireCommandFramework;
 using VampireCommandFramework.Common;
 
@@ -121,7 +121,7 @@ public class CommandContextTests
 	{
 		public IServiceProvider Services => throw new NotImplementedException();
 
-		public string Name => throw new NotImplementedException();
+		public string Name => "GoodName";
 
 		public bool IsAdmin { get; set; } = true;
 
@@ -138,7 +138,7 @@ public class CommandContextTests
 	{
 		public IServiceProvider Services => throw new NotImplementedException();
 
-		public string Name => throw new NotImplementedException();
+		public string Name => "Bad Name";
 
 		public bool IsAdmin { get; set; } = true;
 

--- a/VCF.Tests/HelpTests.cs
+++ b/VCF.Tests/HelpTests.cs
@@ -82,7 +82,7 @@ public class HelpTests
 	{
 		Assert.That(CommandRegistry.Handle(AnyCtx, ".help help-legacy"), Is.EqualTo(CommandResult.Success));
 		AnyCtx.AssertReply($"""
-			[vcf] help-legacy (help-legacy) Passes through a .help command that is compatible with other mods that don't use VCF.
+			[vcf] help-legacy Passes through a .help command that is compatible with other mods that don't use VCF.
 			.help-legacy [search=]
 			Aliases: .help-legacy
 			""");


### PR DESCRIPTION
Now all chat messages that start with . are assumed to be an attempt to execute a command unless it starts with at least two periods.  If the message doesn't match a command then VCF will try to find up to the three closest command matches and offer them as what the person potentially meant to execute.

![image](https://github.com/user-attachments/assets/8d192a34-00c0-450c-918f-3d189772d869)

Various presentation of messages returned from VCF have also been updated with new formatting that should hopefully be generally more readable.