### PR TITLE
Fix unload on client

### DIFF
--- a/VCF.Core/Plugin.cs
+++ b/VCF.Core/Plugin.cs
@@ -34,6 +34,9 @@ internal class Plugin : BasePlugin
 
 	public override bool Unload()
 	{
+		if (!Breadstone.VWorld.IsServer)
+			return true;
+
 		_harmony.UnpatchSelf();
 		return true;
 	}


### PR DESCRIPTION
Unload throws an exception on the client because `_harmony` is uninitialized. Important for a setup where all the plugins are in the same place.