### PR TITLE
Fixing overlap of Assembly Name and Command/Commandgroup

### DIFF
--- a/VCF.Core/Registry/CommandRegistry.cs
+++ b/VCF.Core/Registry/CommandRegistry.cs
@@ -233,12 +233,12 @@ public static class CommandRegistry
 		}
 
 		// Get command(s) based on input
-		CacheResult matchedCommand;
+		CacheResult matchedCommand = null;
 		if (assemblyName != null)
 		{
 			matchedCommand = _cache.GetCommandFromAssembly(commandInput, assemblyName);
 		}
-		else
+		if (matchedCommand == null || !matchedCommand.IsMatched)
 		{
 			matchedCommand = _cache.GetCommand(input);
 		}


### PR DESCRIPTION
### Problem
The plugin Killfeed had it's commands start with killfeed this clashed with the assembly name also being killfeed which meant you need to use for example `.killfeed killfeed`.  This is due to if there was a match at the start with an assembly name it wouldn't fallback in the case of no match to checking all commands with no assembly name specified.

### Solution
If we don't find a match in the assembly specified then do a search over all commands.

### Notes
In future, potentially should handle the commands being overloaded in this case but this is a fairly rare case only brought up due to killfeed prefixing its commands with killfeed.  Not likely that there is overlap of  `.assemblyName command `with some plugin's `.commandgroup command` where commandgroup = assemblyname